### PR TITLE
Urza, Academy Headmaster targeting fix

### DIFF
--- a/forge-game/src/main/java/forge/game/ability/effects/ChooseGenericEffect.java
+++ b/forge-game/src/main/java/forge/game/ability/effects/ChooseGenericEffect.java
@@ -91,7 +91,7 @@ public class ChooseGenericEffect extends SpellAbilityEffect {
                 while (sa.getParam("AtRandom").equals("Urza") && i < chosenSAs.size()) {
                     if (!chosenSAs.get(i).usesTargeting()) {
                         i++;
-                    } else if (sa.getTargetRestrictions().hasCandidates(chosenSAs.get(i))) {
+                    } else if (chosenSAs.get(i).getTargetRestrictions().hasCandidates(chosenSAs.get(i))) {
                         p.getController().chooseTargetsFor(chosenSAs.get(i));
                         i++;
                     } else {


### PR DESCRIPTION
Updates "Urza, Academy Headmaster" specific targeting code to use `targetRestrictions` from the sub abilities (where the targeting restrictions are actually specified) instead of the top level (the raw +1/-1/-6) `SpellAbility` where `targetRestrictions = null`.

Error spawned by Urza's ability selection without this fix:
```
java.lang.NullPointerException: Cannot invoke "forge.game.spellability.TargetRestrictions.hasCandidates(forge.game.spellability.SpellAbility)" because the return value of "forge.game.spellability.SpellAbility.getTargetRestrictions()" is null
	at forge.game.ability.effects.ChooseGenericEffect.resolve(ChooseGenericEffect.java:94)
	at forge.game.ability.AbilityApiBased.resolve(AbilityApiBased.java:41)
	at forge.game.ability.AbilityUtils.resolveApiAbility(AbilityUtils.java:1443)
	at forge.game.ability.AbilityUtils.resolve(AbilityUtils.java:1411)
	at forge.game.zone.MagicStack.resolveStack(MagicStack.java:561)
	at forge.game.phase.PhaseHandler.startFirstTurn(PhaseHandler.java:1150)
	at forge.game.GameAction.startGame(GameAction.java:2113)
	at forge.game.Match.startGame(Match.java:90)
	at forge.gamemodes.match.HostedMatch$2.run(HostedMatch.java:258)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1623)
```
